### PR TITLE
Update paths to API methods

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -12,12 +12,7 @@
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
-        <option name="myModules">
-          <set>
-            <option value="$PROJECT_DIR$" />
-            <option value="$PROJECT_DIR$/app" />
-          </set>
-        </option>
+        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/app/src/main/java/com/nolan/mmcs_schedule/repository/api/ScheduleApi.java
+++ b/app/src/main/java/com/nolan/mmcs_schedule/repository/api/ScheduleApi.java
@@ -20,36 +20,36 @@ import retrofit.http.Path;
  */
 public interface ScheduleApi {
 
-    @GET("/grade/list")
+    @GET("/APIv0/grade/list")
     RawGrade.List getGrades();
 
-    @GET("/group/list/{gradeID}")
+    @GET("/APIv0/group/list/{gradeID}")
     RawGroup.List getGroups(@Path("gradeID") int gradeId);
 
-    @GET("/group/forUber/{uberID}")
+    @GET("/APIv0/group/forUber/{uberID}")
     RawGroup.List getGroupsOfUberGroup(@Path("uberID") int uberId);
 
-    @GET("/room/list")
+    @GET("/APIv0/room/list")
     RawRoom.List getRooms();
 
-    @GET("/schedule/lesson/{ID}")
+    @GET("/APIv0/schedule/lesson/{ID}")
     RawCurriculaOfLesson getCurriculaForLesson(@Path("ID") int id);
 
-    @GET("/schedule/group/{ID}")
+    @GET("/APIv0/schedule/group/{ID}")
     RawScheduleOfGroup getScheduleOfGroup(@Path("ID") int id);
 
-    @GET("/schedule/teacher/{ID}")
+    @GET("/APIv0/schedule/teacher/{ID}")
     RawScheduleOfTeacher getScheduleOfTeacher(@Path("ID") int id);
 
-    @GET("/subject/list")
+    @GET("/APIv0/subject/list")
     RawSubject.List getSubjects();
 
-    @GET("/teacher/list")
+    @GET("/APIv0/teacher/list")
     RawTeacher.List getTeachers();
 
-    @GET("/time/week")
+    @GET("/APIv0/time/week")
     RawWeek getCurrentWeek();
 
-    @GET("/time/list")
+    @GET("/APIv0/time/list")
     RawTimeSlot.List getTimeSlots();
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Дабы не возникало проблем при обновлении методов API, лучше явно указывать версию метода, вместо использования последней доступной.
